### PR TITLE
Reflect "VSTS" > "Azure DevOps" rebrand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# VSTS PullRequest Monitor
+# Azure DevOps PullRequest Monitor
 
-This is a chrome extension which would monitor all the repositories in a given VSTS project for active Pull Requests and lists them as links so that the developers can monitor what needs to be reviewed.
+This is a chrome extension which would monitor all the repositories in a given Azure DevOps project for active Pull Requests and lists them as links so that the developers can monitor what needs to be reviewed.
 
 ## Usage
 
-Click on SETTINGS link to configure the extension with your VSTS organisation and Project.
+Click on SETTINGS link to configure the extension with your Azure DevOps organisation and Project.
 
-Note that you'll need to have an active session with VSTS in order to retreive the list of pull requests.
+Note that you'll need to have an active session with Azure DevOps in order to retreive the list of pull requests.
 
 ## Development
 

--- a/public/background.js
+++ b/public/background.js
@@ -30,7 +30,7 @@ chrome.storage.onChanged.addListener((changes, namespace) => {
 });
 
 const fetchData = settings => {
-  const url = `https://${settings.subdomain}.visualstudio.com/${
+  const url = `https://dev.azure.com/${settings.subdomain}/${
     settings.projectPath
   }/_apis/git/pullrequests?api-version=4.1`;
   console.log("PR Monitor fetching from ", url);

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,8 @@
 {
   "short_name": "PR",
   "name": "PR Monitor",
-  "version": "0.2",
-  "description": "VSTS Pull Request Monitor",
+  "version": "0.3",
+  "description": "Azure DevOps Pull Request Monitor",
   "icons": {
     "48": "pr-monitor-48x48.png",
     "128": "pr-monitor-128x128.png"
@@ -16,5 +16,5 @@
     "scripts": ["background.js"],
     "persistent": false
   },
-  "permissions": ["cookies", "*://*.visualstudio.com/", "storage", "alarms"]
+  "permissions": ["cookies", "*://*.visualstudio.com/", "https://dev.azure.com/*", "storage", "alarms"]
 }

--- a/src/App.js
+++ b/src/App.js
@@ -70,7 +70,7 @@ class App extends Component {
     return (
       <div className="App">
         <header className="App-header">
-          <div className="App-title">VSTS Pull Requests</div>
+          <div className="App-title">Azure DevOps Pull Requests</div>
           <div className="App-title-controls">
             <p>{subtitle}</p>
             <p>

--- a/src/components/pr-item/pr-item.js
+++ b/src/components/pr-item/pr-item.js
@@ -18,7 +18,7 @@ export const PRItem = props => {
       <a
         className="pr-item-link"
         target="_blank"
-        href={`https://${subdomain}.visualstudio.com/${projectPath}/_git/${repositoryName}/pullrequest/${pullRequestId}?_a=overview`}
+        href={`https://dev.azure.com/${subdomain}/${projectPath}/_git/${repositoryName}/pullrequest/${pullRequestId}?_a=overview`}
       >
         <div className="pr-item-link-body">
           <div className="pr-item-title">

--- a/src/components/pr-item/pr-item.test.js
+++ b/src/components/pr-item/pr-item.test.js
@@ -15,7 +15,7 @@ it("renders a link to the PR", () => {
     createdBy: {
       displayName: "Allen Iverson",
       imageUrl:
-        "https://testOrg.visualstudio.com/_api/_common/identityImage?id=f50c1460-aff7-46d7-a6d5-64f0a778e865"
+        "https://dev.azure.com/testOrg/_api/_common/identityImage?id=f50c1460-aff7-46d7-a6d5-64f0a778e865"
     },
     creationDate: "2018-05-11T10:41:42.535574Z",
     title: "Test Title 1"
@@ -35,7 +35,7 @@ it("renders a link to the PR", () => {
   const linkItem = wrapper.find(".pr-item-link");
   expect(linkItem.exists()).toBe(true);
   expect(linkItem.get(0).props.href).toBe(
-    `https://${testProps.subdomain}.visualstudio.com/${
+    `https://dev.azure.com/${testProps.subdomain}/${
       testProps.projectPath
     }/_git/${testProps.repositoryName}/pullrequest/${
       testProps.pullRequestId

--- a/src/components/pr-list/pr-list.test.js
+++ b/src/components/pr-list/pr-list.test.js
@@ -17,7 +17,7 @@ it("renders PR list", () => {
       createdBy: {
         displayName: "Allen Iverson",
         imageUrl:
-          "https://testOrg.visualstudio.com/_api/_common/identityImage?id=f50c1460-aff7-46d7-a6d5-64f0a778e865"
+          "https://dev.azure.com/testOrg/_api/_common/identityImage?id=f50c1460-aff7-46d7-a6d5-64f0a778e865"
       },
       creationDate: "2018-05-11T10:41:42.535574Z",
       title: "Test Title 1"
@@ -34,7 +34,7 @@ it("renders PR list", () => {
       createdBy: {
         displayName: "Kevin Garnett",
         imageUrl:
-          "https://testOrg.visualstudio.com/_api/_common/identityImage?id=aa8ecfd8-e920-6c0e-ae07-46f9f3170bce"
+          "https://dev.azure.com/testOrg/_api/_common/identityImage?id=aa8ecfd8-e920-6c0e-ae07-46f9f3170bce"
       },
       creationDate: "2018-05-10T14:30:42.3139207Z",
       title: "Test title 2"

--- a/src/components/settings/settings-panel.css
+++ b/src/components/settings/settings-panel.css
@@ -10,7 +10,7 @@
 }
 
 .settings-panel-input-container > label {
-  min-width: 140px;
+  min-width: 190px;
 }
 
 .settings-panel-controls {

--- a/src/components/settings/settings-panel.js
+++ b/src/components/settings/settings-panel.js
@@ -24,9 +24,9 @@ class SettingsPanel extends Component {
       <div className="settings-panel">
         <form>
           <div className="settings-panel-input-container">
-            <label htmlFor="vsts-account-input">VSTS Account:</label>
+            <label htmlFor="azure-devops-account-input">Azure DevOps Account:</label>
             <input
-              id="vsts-account-input"
+              id="azure-devops-account-input"
               type="text"
               name="project"
               value={accountName}
@@ -34,12 +34,11 @@ class SettingsPanel extends Component {
               required
               minLength={3}
             />
-            .visualstudio.com
           </div>
           <div className="settings-panel-input-container">
-            <label htmlFor="vsts-project-input">VSTS Project:</label>
+            <label htmlFor="azure-devops-project-input">Azure DevOps Project:</label>
             <input
-              id="vsts-project-input"
+              id="azure-devops-project-input"
               type="text"
               name="project"
               value={projectName}


### PR DESCRIPTION
Update the extension to remove references to VSTS and replace them with the new "Azure DevOps" brand name. Also rewrite static portions of urls to begin ```https://dev.azure.com/:accountName``` instead of ```https://:accountName.visualstudio.com```.